### PR TITLE
consistent defaults for tracing content

### DIFF
--- a/openllmtelemetry/instrumentation/bedrock/__init__.py
+++ b/openllmtelemetry/instrumentation/bedrock/__init__.py
@@ -45,7 +45,7 @@ WRAPPED_METHODS = [{"package": "botocore.client", "object": "ClientCreator", "me
 
 
 def should_send_prompts():
-    return (os.getenv("TRACE_PROMPT_AND_RESPONSE") or "true").lower() == "true" or context_api.get_value("override_enable_content_tracing")
+    return (os.getenv("TRACE_PROMPT_AND_RESPONSE") or "false").lower() == "true" or context_api.get_value("override_enable_content_tracing")
 
 
 def _set_span_attribute(span, name, value):


### PR DESCRIPTION
Bedrock trace content was defaulting to opt-out, but we want the behavior to be consistent and be opt-in defaulting to no content traced for prompts/responses