### PR TITLE
Fix README.md code example to align with env variable renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ import os
 
 os.environ["WHYLABS_API_KEY"] = "<your-whylabs-api-key>"
 os.environ["WHYLABS_DEFAULT_DATASET_ID"] = "<your-llm-resource-id>"
-os.environ["WHYLABS_GUARD_ENDPOINT"] = "<your container endpoint>"
-os.environ["WHYLABS_GUARD_API_KEY"] = "internal-secret-for-whylabs-Secure"
+os.environ["GUARDRAILS_ENDPOINT"] = "<your container endpoint>"
+os.environ["GUARDRAILS_API_KEY"] = "internal-secret-for-whylabs-Secure"
 ```
 
 Once this is done, all of your OpenAI interactions will be automatically traced. If you have rulesets enabled for blocking in WhyLabs Secure policy, the library will block requests accordingly

--- a/notebooks/Instrumenting_Bedrock.ipynb
+++ b/notebooks/Instrumenting_Bedrock.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "Note: The example assumes you boto3 credentials are working to be able to invoke bedrock-runtime models, for details see [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)\n",
     "\n",
-    "In order to send the traces to whylabs you need to configure your model-id and WhyLabs API keys first. If you also want to onboard with WhyLabs Guardrail API, see further details on how to do that [here](https://docs.whylabs.ai/docs/secure/guardrails-api), and after you setup your endpoint you can use that in the `WHYLABS_GUARD_ENDPOINT` below. You can skip that part for now to see straghtforward LLM tracing in WhyLabs platform, but you will get better insights and security by using the WhyLabs Guardrail API as that will add additional metrics to your traces."
+    "In order to send the traces to whylabs you need to configure your model-id and WhyLabs API keys first. If you also want to onboard with WhyLabs Guardrail API, see further details on how to do that [here](https://docs.whylabs.ai/docs/secure/guardrails-api), and after you setup your endpoint you can use that in the `GUARDRAILS_ENDPOINT` below. You can skip that part for now to see straghtforward LLM tracing in WhyLabs platform, but you will get better insights and security by using the WhyLabs Guardrail API as that will add additional metrics to your traces."
    ]
   },
   {
@@ -40,8 +40,8 @@
     "\n",
     "os.environ[\"WHYLABS_API_KEY\"] = \"replace-with-whylabs-api-key\"\n",
     "os.environ[\"WHYLABS_DEFAULT_DATASET_ID\"] = \"replace-with-model-id\" #  e.g. \"model-1\"\n",
-    "os.environ[\"WHYLABS_GUARD_ENDPOINT\"] = \"\"\n",
-    "os.environ[\"WHYLABS_GUARD_API_KEY\"] = \"\""
+    "os.environ[\"GUARDRAILS_ENDPOINT\"] = \"\"\n",
+    "os.environ[\"GUARDRAILS_API_KEY\"] = \"\""
    ]
   },
   {


### PR DESCRIPTION
Update the env variables to match the updated guardrail config keys