### PR TITLE
Fix openai v0 guardrail support

### DIFF
--- a/openllmtelemetry/instrumentation/bedrock/__init__.py
+++ b/openllmtelemetry/instrumentation/bedrock/__init__.py
@@ -183,10 +183,7 @@ def _instrumented_model_invoke(fn, tracer, secure_api: GuardrailsApi):
                     _set_amazon_titan_span_attributes(span, request_body, {})
 
             def response_extractor(r):
-                if is_openai_v1():
-                    response_dict = model_as_dict(r)
-                else:
-                    response_dict = r
+                response_dict = r
                 return response_dict["choices"][0]["text"]
 
             # TODO: check for input text first

--- a/openllmtelemetry/instrumentation/openai/shared/__init__.py
+++ b/openllmtelemetry/instrumentation/openai/shared/__init__.py
@@ -56,7 +56,7 @@ def _set_api_attributes(span, instance=None):
         _set_span_attribute(span, "llm.base_url", str(base_url))
         _set_span_attribute(span, OPENAI_API_TYPE, openai.api_type)
         _set_span_attribute(span, OPENAI_API_VERSION, openai.api_version)
-        _set_span_attribute(span, "openapi.client.version", openai.__version__)
+        _set_span_attribute(span, "openai.client.version", openai.version.VERSION)
     except Exception as ex:  # pylint: disable=broad-except
         logger.warning("Failed to set api attributes for openai span, error: %s", str(ex))
 

--- a/openllmtelemetry/instrumentation/openai/shared/chat_wrappers.py
+++ b/openllmtelemetry/instrumentation/openai/shared/chat_wrappers.py
@@ -83,10 +83,10 @@ def chat_wrapper(tracer, guardrails_api: GuardrailsApi, wrapped, instance, args,
     if host and host.endswith(".openai.com"):
         vendor = "OpenAI"
         span_name = "openai.chat"
-    elif host.endswith(".azure.com"):
+    elif host and host.endswith(".azure.com"):
         vendor = "AzureOpenAI"
         span_name = "azureopenai.chat"
-    elif host.endswith(".nvidia.com"):
+    elif host and host.endswith(".nvidia.com"):
         vendor = "Nvidia"
         span_name = "nvidia.nim.chat"
 

--- a/openllmtelemetry/instrumentation/openai/v0/__init__.py
+++ b/openllmtelemetry/instrumentation/openai/v0/__init__.py
@@ -43,7 +43,7 @@ _instruments = ("openai >= 0.27.0", "openai < 1.0.0")
 
 class OpenAIV0Instrumentor(BaseInstrumentor):
     def __init__(self, guard: Optional[GuardrailsApi]):
-        self._guard = guard
+        self._secure_api = guard
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
@@ -52,12 +52,12 @@ class OpenAIV0Instrumentor(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
         tracer = get_tracer(__name__, __version__, tracer_provider)
 
-        wrap_function_wrapper("openai", "Completion.create", completion_wrapper(tracer))
-        wrap_function_wrapper("openai", "Completion.acreate", acompletion_wrapper(tracer))
-        wrap_function_wrapper("openai", "ChatCompletion.create", chat_wrapper(tracer))
-        wrap_function_wrapper("openai", "ChatCompletion.acreate", achat_wrapper(tracer))
-        wrap_function_wrapper("openai", "Embedding.create", embeddings_wrapper(tracer))
-        wrap_function_wrapper("openai", "Embedding.acreate", aembeddings_wrapper(tracer))
+        wrap_function_wrapper("openai", "Completion.create", completion_wrapper(tracer, self._secure_api))
+        wrap_function_wrapper("openai", "Completion.acreate", acompletion_wrapper(tracer, self._secure_api))
+        wrap_function_wrapper("openai", "ChatCompletion.create", chat_wrapper(tracer, self._secure_api))
+        wrap_function_wrapper("openai", "ChatCompletion.acreate", achat_wrapper(tracer, self._secure_api))
+        wrap_function_wrapper("openai", "Embedding.create", embeddings_wrapper(tracer, self._secure_api))
+        wrap_function_wrapper("openai", "Embedding.acreate", aembeddings_wrapper(tracer, self._secure_api))
 
     def _uninstrument(self, **kwargs):
         pass

--- a/openllmtelemetry/instrumentation/openai/v1/__init__.py
+++ b/openllmtelemetry/instrumentation/openai/v1/__init__.py
@@ -17,7 +17,7 @@ Changes made: customization for WhyLabs
 
 Original source: openllmetry: https://github.com/traceloop/openllmetry
 """
-from typing import Collection
+from typing import Collection, Optional
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.trace import get_tracer
@@ -42,7 +42,7 @@ _instruments = ("openai >= 1.0.0",)
 
 
 class OpenAIV1Instrumentor(BaseInstrumentor):
-    def __init__(self, guard: GuardrailsApi):
+    def __init__(self, guard: Optional[GuardrailsApi]):
         self._secure_api = guard
 
     def instrumentation_dependencies(self) -> Collection[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "OpenLLMTelemetry"
-version = "0.0.1.b9"
+version = "0.0.1.b14"
 description = "End-to-end observability with built-in security guardrails."
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ opentelemetry-api = "^1.21.0"
 opentelemetry-sdk = "^1.21.0"
 opentelemetry-exporter-otlp-proto-http = "^1.22.0"
 opentelemetry-instrumentation-requests = "^0.43b0"
-openai = {version = ">0.7,<2.0", optional = true}
+openai = {version = ">=0.27,<2.0", optional = true}
 boto3 = {version = "^1.18.67", optional = true}
 whylogs-container-client = "^1.0.15"
 


### PR DESCRIPTION
* There is an issue with using older OpenAI libraries and the version dependency was too relaxed for allowing versions of openai before 0.27.0
* incidental bug fixes for hostname attributes
* incidental fix for openai client version trace attribute
* update version to 0.0.1b14