### PR TITLE
Add a default format blocked bedrock messages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1.b15
+current_version = 0.0.1.b17
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 

--- a/openllmtelemetry/instrumentation/bedrock/__init__.py
+++ b/openllmtelemetry/instrumentation/bedrock/__init__.py
@@ -185,8 +185,8 @@ def _instrumented_model_invoke(fn, tracer, secure_api: GuardrailsApi):
                 else:
                     content = f"Response blocked by WhyLabs: {eval_result.action.block_message}"
                 blocked_message = os.environ.get("GUARDRAILS_BLOCKED_MESSAGE_OVERRIDE", content)
-                if vendor == "amazon":
-                    response_content = json.dumps({
+                # default to Amazon's response format
+                response_content = json.dumps({
                             "inputTextTokenCount": 0,
                             "results": [
                                 {
@@ -196,7 +196,7 @@ def _instrumented_model_invoke(fn, tracer, secure_api: GuardrailsApi):
                                 }
                             ]
                         }).encode('utf-8')
-                elif vendor == "meta":
+                if vendor == "meta":
                      response_content = json.dumps({
                         "generation": blocked_message,
                         "prompt_token_count": 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "OpenLLMTelemetry"
-version = "0.0.1.b16"
+version = "0.0.1.b17"
 description = "End-to-end observability with built-in security guardrails."
 authors = ["WhyLabs.ai <support@whylabs.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Using the amazon titan response as default

Supported bedrock invoked models in this release include:
Amazon Titan *
Anthropic models
Meta's Llama * models

